### PR TITLE
Add a retry_on_timeout decorator and use it on the lowest-level visit step

### DIFF
--- a/aloe_webdriver/__init__.py
+++ b/aloe_webdriver/__init__.py
@@ -19,8 +19,9 @@ from aloe_webdriver.util import (
     find_field,
     find_option,
     option_in_select,
-    wait_for,
+    retry_on_timeout,
     string_literal,
+    wait_for,
 )
 
 from nose.tools import (
@@ -72,6 +73,7 @@ def contains_content(browser, content):
 
 @step('I visit "(.*?)"$')
 @step('I go to "(.*?)"$')
+@retry_on_timeout
 def visit(self, url):
     """Navigate to the provided (fully qualified) URL."""
     world.browser.get(url)

--- a/aloe_webdriver/util.py
+++ b/aloe_webdriver/util.py
@@ -13,6 +13,7 @@ from builtins import str
 import operator
 from copy import copy
 from time import time, sleep
+from functools import wraps
 from selenium.common.exceptions import TimeoutException
 
 try:
@@ -486,6 +487,7 @@ def wait_for(func):
     for (default 15).
     """
 
+    @wraps(func)
     def wrapped(*args, **kwargs):
         timeout = kwargs.pop('timeout', TIMEOUT)
 
@@ -523,6 +525,7 @@ def retry_on_timeout(func):
     for (default 5).
     """
 
+    @wraps(func)
     def wrapped(*args, **kwargs):
         retries = kwargs.pop('retries', RETRIES)
 

--- a/aloe_webdriver/util.py
+++ b/aloe_webdriver/util.py
@@ -13,6 +13,7 @@ from builtins import str
 import operator
 from copy import copy
 from time import time, sleep
+from selenium.common.exceptions import TimeoutException
 
 try:
     reduce
@@ -503,6 +504,34 @@ def wait_for(func):
                     start = time()
                 if time() - start < timeout:
                     sleep(CHECK_EVERY)
+                    continue
+                else:
+                    raise
+
+    return wrapped
+
+
+RETRIES = 5
+
+
+def retry_on_timeout(func):
+    """
+    A decorator to invoke a function, retrying on timeout exceptions for a
+    specified number of times.
+
+    Adds a kwarg `retires` to `func` which is the number of times to try
+    for (default 5).
+    """
+
+    def wrapped(*args, **kwargs):
+        retries = kwargs.pop('retries', RETRIES)
+
+        while True:
+            try:
+                return func(*args, **kwargs)
+            except TimeoutException:
+                retries -= 1
+                if retries > 0:
                     continue
                 else:
                     raise


### PR DESCRIPTION
We have seen cases where the PhantomJS webdriver appears to hang
indefinitely. We're not sure what's causing these, but other people
seem to be hitting them as well, see:

https://github.com/ariya/phantomjs/issues/11526

We have been able to get selenium to raise a TimeoutException by calling:

```
browser.set_page_load_timeout(20)  # in seconds
```

For a complete solution, we need to respond to the TimeoutException by
retrying the page load. This commit adds that try/except block by
means of a new decorator named @retry_on_timeout, (which, other than
which exception is caught, (and not doing any sleeping), is _very_
similar to the existing @wait_for decorator).
